### PR TITLE
Process subtitles as image captions

### DIFF
--- a/src/templates.js
+++ b/src/templates.js
@@ -12,9 +12,9 @@ function workbook(id, title, objectives, body, bib) {
     xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="${id}">
     <head>
       <title>${encodeXml(title)}</title>
-      ${objectives}
-    </head>
+      </head>
     <body>
+      ${objectives}
       ${body}
     </body>
     ${bib}

--- a/src/templates.js
+++ b/src/templates.js
@@ -12,7 +12,7 @@ function workbook(id, title, objectives, body, bib) {
     xmlns:wb="http://oli.web.cmu.edu/activity/workbook/" id="${id}">
     <head>
       <title>${encodeXml(title)}</title>
-      </head>
+    </head>
     <body>
       ${objectives}
       ${body}

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,18 @@ function encodeXml (s) {
           .replace(/'/g, '&apos;');
 };
 
+function checkImageTag (s) {
+  if (typeof s === 'string' || s instanceof String) {
+    s = s.trim();
+    s = s.substring(0, s.indexOf(' '));
+    if (s === '<image') {
+      return true;
+    }
+  }
+  return false;
+};
+
 module.exports = {
   encodeXml,
+  checkImageTag,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 
 function encodeXml (s) {
+  s = String(s);
   return s.replace(/&/g, '&amp;')
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -537,7 +537,7 @@ function processContent(context, c) {
       // modify the last line, which is an image tag to add alt text
       // assume alt text only span 1 line
       let new_s = context.lines[currentIdx];
-      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + " alt=\"" + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + "\"/>";
+      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + ' alt=\"' + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + ' \"/>';
     }
 
   } else if (c.table !== undefined) {

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -529,6 +529,9 @@ function processContent(context, c) {
   } else if (c.paragraph !== undefined && c.paragraph.paragraphStyle.namedStyleType === 'NORMAL_TEXT') {
     processParagraph(context, c.paragraph);
 
+  } else if (c.paragraph !== undefined && c.paragraph.paragraphStyle.namedStyleType === 'SUBTITLE') {
+    processParagraph(context, c.paragraph);
+
   } else if (c.table !== undefined) {
 
     const customElement = extractCustomElementName(c.table);

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -536,7 +536,8 @@ function processContent(context, c) {
     if (checkImageTag(s)) {
       // modify the last line, which is an image tag to add alt text
       // assume alt text only span 1 line
-      context.lines[currentIdx-1] = s.substring(0, s.indexOf('>')) + "alt=\"" + context.lines[currentIdx] + "\">";
+      let new_s = context.lines[currentIdx];
+      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + "alt=\"" + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + "\"/>";
     }
 
   } else if (c.table !== undefined) {

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const readline = require('readline');
 const { google } = require('googleapis');
-const { encodeXml } = require('./utils');
+const { encodeXml, checkImageTag } = require('./utils');
 const { workbook } = require('./templates');
 var guid = require('./guid').guid;
 const fetchIt = require('node-fetch');
@@ -530,7 +530,14 @@ function processContent(context, c) {
     processParagraph(context, c.paragraph);
 
   } else if (c.paragraph !== undefined && c.paragraph.paragraphStyle.namedStyleType === 'SUBTITLE') {
+    let currentIdx = context.lines.length;
+    let s = context.lines[currentIdx-1];
     processParagraph(context, c.paragraph);
+    if (checkImageTag(s)) {
+      // modify the last line, which is an image tag to add alt text
+      // assume alt text only span 1 line
+      context.lines[currentIdx-1] = s.substring(0, s.indexOf('>')) + "alt=\"" + context.lines[currentIdx] + "\">";
+    }
 
   } else if (c.table !== undefined) {
 

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -537,7 +537,7 @@ function processContent(context, c) {
       // modify the last line, which is an image tag to add alt text
       // assume alt text only span 1 line
       let new_s = context.lines[currentIdx];
-      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + ' alt=\"' + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + ' \"/>';
+      context.lines[currentIdx-1] = `${s.substring(0, s.indexOf('/>'))} alt="${new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>'))}" />`;
     }
 
   } else if (c.table !== undefined) {

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -537,7 +537,7 @@ function processContent(context, c) {
       // modify the last line, which is an image tag to add alt text
       // assume alt text only span 1 line
       let new_s = context.lines[currentIdx];
-      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + "alt=\"" + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + "\"/>";
+      context.lines[currentIdx-1] = s.substring(0, s.indexOf('/>')) + " alt=\"" + new_s.substring(new_s.indexOf('>') + 1, new_s.indexOf('</p>')) + "\"/>";
     }
 
   } else if (c.table !== undefined) {

--- a/src/workbook.js
+++ b/src/workbook.js
@@ -108,7 +108,7 @@ function processPage(data) {
   console.log(context.objrefs);
   const objectives = context.objrefs.length === 0
     ? ''
-    : context.objrefs.map(o => `<objref>${o}</objref>`).reduce((p, c) => p + c + '\n', '');
+    : context.objrefs.map(o => `<objref idref="${o}" />`).reduce((p, c) => p + c + '\n', '');
 
   const body = context.lines.reduce((p, c) => p + c + '\n', '')
   const xml = workbook(id, title, objectives, body, '');


### PR DESCRIPTION
The major change is that Google docs 'subtitle' are now also included in the eventual XML output.

Subtitles can be processed as image captions, and alt text will be added for images that appear just before a 'subtitle' element.

Other minor changes/bugfixes include:
- Assessments which have cells that are treated as numbers will no longer cause an error when passed through the `encodeXML` method
- References to objectives are written as `idref` attributes instead